### PR TITLE
Add README and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# Host TalkDrove (HTD-V1)
+
+Host TalkDrove is a Node.js application that provides a web interface for hosting and managing bots.
+It offers authentication, dashboard views, admin and moderator tools, deployment helpers and wallet
+features. The project uses Express for the HTTP server, EJS for templating and MySQL for persistence.
+
+## Features
+
+- User authentication with signup, login and password reset routes
+- Admin interface for managing bots, users, API keys and support tickets
+- Moderator routes for handling bot reports and deposit requests
+- Bot deployment workflows with Heroku integration
+- Wallet and payment endpoints for coin deposits and purchases
+- REST style APIs under `api/routes/apis`
+
+## Project Structure
+
+```
+Hamza.js               # Application entry point
+api/                   # API routes, middlewares and database helpers
+public/                # Static files served by Express
+views/                 # EJS views used for server-rendered pages
+```
+
+## Scripts
+
+- `npm start` – start the application
+- `npm run dev` – start with nodemon for development
+
+## Environment Variables
+
+Create a `.env` file in the project root and provide the following variables:
+
+```
+DB_HOST=
+DB_USER=
+DB_PASSWORD=
+DB_NAME=
+SESSION_SECRET=
+NODE_ENV=production
+PORT=3000
+SITE_URL=
+MAINTENANCE_MODE=false
+HTD_API_KEY=
+CREEM_API_URL=
+CREEM_API_KEY=
+```
+
+`SESSION_SECRET` should be a random string used to sign cookies. The database settings should point to a
+MySQL server. Update `PORT` if you want the server to listen on a different port.
+
+## Running the Application
+
+Install dependencies and run the server:
+
+```bash
+npm install
+npm start
+```
+
+The service will listen on the port configured in the `.env` file (default `3000`).
+
+For additional details about preparing the environment and database, see
+[`docs/setup.md`](docs/setup.md).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,38 @@
+# Setup Guide
+
+This document explains how to configure and run the Host TalkDrove application on your own server.
+
+## Prerequisites
+
+- **Node.js** (version 14 or newer)
+- **npm** for installing dependencies
+- **MySQL** server for the application database
+
+## Installation Steps
+
+1. **Clone the repository**
+   ```bash
+   git clone <repo-url>
+   cd HTD-V1
+   ```
+2. **Install dependencies**
+   ```bash
+   npm install
+   ```
+3. **Configure environment variables**
+   - Copy `.env` from the repository and fill in your database credentials and other values.
+   - Ensure the MySQL server is reachable with the credentials provided.
+4. **Initialize the database**
+   - Create the database specified in `DB_NAME`.
+   - Import any schema required by the application (tables such as `users`, `bots`, etc.).
+5. **Start the development server**
+   ```bash
+   npm run dev
+   ```
+   This uses `nodemon` and reloads on file changes.
+6. **Start for production**
+   ```bash
+   npm start
+   ```
+
+The application will be available on the port set in the `.env` file.


### PR DESCRIPTION
## Summary
- add a project README with an overview and env details
- document installation and configuration steps in `docs/setup.md`

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_687c91ce94f88329b0808470704548e0